### PR TITLE
Add displayName parameter to constructor of credential manager

### DIFF
--- a/src/overrides/CredentialManager.override.ts
+++ b/src/overrides/CredentialManager.override.ts
@@ -36,8 +36,8 @@ export = class CredentialManagerOverrides extends AbstractCredentialManager {
 
     private consoleLog = Logger.getConsoleLogger();
 
-    constructor(service: string) {
-        super(service);
+    constructor(service: string, displayName: string) {
+        super(service, displayName);
     }
 
     public async deleteCredentials(account: string) {


### PR DESCRIPTION
Allows display name to function when using sample CLI credential management