### PR TITLE
fix old doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Zowe CLI Sample Plug-in
 This repository contains a sample Zowe CLI plug-in that adheres to the contribution guidelines for the project. Use this project and the associated tutorials as a starting point for creating Zowe CLI plug-ins. 
 
-* [Why Create a Zowe CLI Plug-in?](#Why-create-a-zowe-cli-plug-in?)
-* [Tutorials, Documentation, and Guidelines](#Tutorials-Documentation-and-Guidelines)
-* [Prerequisites](#prerequisites)
-* [Create a Local Development Space](#create-a-local-development-space)
+- [Zowe CLI Sample Plug-in](#zowe-cli-sample-plug-in)
+  - [Why Create a Zowe CLI Plug-in?](#why-create-a-zowe-cli-plug-in)
+  - [Tutorials, Documentation, and Guidelines](#tutorials-documentation-and-guidelines)
+  - [Prerequisites](#prerequisites)
+  - [Create a Local Development Space](#create-a-local-development-space)
 
 ## Why Create a Zowe CLI Plug-in?
 You might want to create a Zowe CLI plug-in to accomplish the following:
@@ -16,7 +17,7 @@ You might want to create a Zowe CLI plug-in to accomplish the following:
 We also provide the following tutorials, guidelines, and documentation to assist you during development:
 
 ### Tutorials
-To learn about how to work with this sample plug-in, build new commands, or build a new Zowe CLI plug-in, see [Develop for Zowe CLI](https://zowe.github.io/docs-site/latest/extend/extend-cli/cli-devTutorials.html).
+To learn about how to work with this sample plug-in, build new commands, or build a new Zowe CLI plug-in, see [Develop for Zowe CLI](https://docs.zowe.org/stable/extend/extend-cli/cli-devTutorials.html).
 
 ### Contribution Guidelines 
 The Zowe CLI [contribution guidelines](CONTRIBUTING.md) contain standards and conventions for developing Zowe CLI plug-ins. 
@@ -30,7 +31,7 @@ The guidelines contain critical information about working with the code, running
 Reference the [Jenkinsfile Guidelines](CICD-TEMPLATE.md) for information about setting up and maintaining automated testing/deployment for your plug-in with Jenkins automation server. 
 
 ## Prerequisites
-Before you work with the Zowe CLI sample plug-in, [install Zowe CLI globally.](https://zowe.github.io/docs-site/latest/user-guide/cli-installcli.html)
+Before you work with the Zowe CLI sample plug-in, [install Zowe CLI globally.](https://docs.zowe.org/stable/user-guide/cli-installcli.html)
 
 ## Create a Local Development Space
 To create your development space, clone and build the Zowe CLI sample plug-in from source.


### PR DESCRIPTION
Fixing doc links on incremental branch. 

Note that our tutorial indicates users need a branch named `develop-a-plugin` for one portion of the tutorial, but such a branch branch no longer exists. It would be good to revisit our tutorials in the future to determine: 

- How current and accurate are the tutorials? What is outdated, what could be improved, etc...? Has anyone followed the tutorials and successfully created a plug-in with little-to-no outside help? 
- Do people know about the tutorials?  Are they actually following them? Why or why not? 