### PR TITLE
Method name changed for clarity

### DIFF
--- a/src/api/Typicode.ts
+++ b/src/api/Typicode.ts
@@ -16,12 +16,12 @@ export class Typicode {
 
     public static readonly TODO_URI = "/todos";
 
-    public static getTodos(session: AbstractSession): Promise<ITodo[]> {
+    public static getAllTodos(session: AbstractSession): Promise<ITodo[]> {
         Logger.getAppLogger().trace("Typicode.getTodos() called");
         return RestClient.getExpectJSON<ITodo[]>(session, Typicode.TODO_URI);
     }
 
-    public static getTodo(session: AbstractSession, id: number): Promise<ITodo> {
+    public static getSingleTodo(session: AbstractSession, id: number): Promise<ITodo> {
         Logger.getAppLogger().trace("Typicode.getTodos() called with id " + id);
         ImperativeExpect.toNotBeNullOrUndefined(id, "id must be provided");
         const resource = Typicode.TODO_URI + "/" + id;

--- a/src/cli/list/typicode-todos/TypicodeTodos.handler.ts
+++ b/src/cli/list/typicode-todos/TypicodeTodos.handler.ts
@@ -18,11 +18,11 @@ export default class TypicodeTodosHandler implements ICommandHandler {
 
         const session = new Session({ hostname: TypicodeTodosHandler.TYPICODE_HOST});
         if (params.arguments.id) {
-            const todo = await Typicode.getTodo(session, params.arguments.id);
+            const todo = await Typicode.getSingleTodo(session, params.arguments.id);
             params.response.data.setObj(todo);
             params.response.console.log(TextUtils.prettyJson(todo));
         } else {
-            const todos = await Typicode.getTodos(session);
+            const todos = await Typicode.getAllTodos(session);
             params.response.data.setObj(todos);
             params.response.console.log(TextUtils.prettyJson(todos));
         }


### PR DESCRIPTION
Changed the method names "getTodo" and "getTodos" to "getAllTodos" and "getSingleTodo" to improve clarity.
