### PR TITLE
Use legacy npm login instead of token

### DIFF
--- a/.github/workflows/zowe-cli-plugin.yml
+++ b/.github/workflows/zowe-cli-plugin.yml
@@ -90,4 +90,6 @@ jobs:
         GIT_COMMITTER_NAME: zowe-robot
         GIT_COMMITTER_EMAIL: zowe.robot@gmail.com
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
+        NPM_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+        NPM_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+        NPM_EMAIL: zowe.robot@gmail.com


### PR DESCRIPTION
Signed-off-by: Timothy Johnson <timothy.johnson@broadcom.com>