### PR TITLE
Fix IHandlerParameters mocks in unit tests

### DIFF
--- a/__tests__/__integration__/cli/fail/__snapshots__/cli.fail.test.integration.test.ts.snap
+++ b/__tests__/__integration__/cli/fail/__snapshots__/cli.fail.test.integration.test.ts.snap
@@ -25,19 +25,19 @@ exports[`zowe-cli-sample fail command should display the help 1`] = `
  GLOBAL OPTIONS
  --------------
 
-   --response-format-json  | --rfj (boolean)
+   --response-format-json | --rfj (boolean)
 
       Produce JSON formatted data from a command
 
-   --help  | -h (boolean)
+   --help | -h (boolean)
 
       Display help text
 
-   --help-examples  (boolean)
+   --help-examples (boolean)
 
       Display examples for all the commands in a group
 
-   --help-web  | --hw (boolean)
+   --help-web | --hw (boolean)
 
       Display HTML help in browser
 

--- a/__tests__/__integration__/cli/list/__resources__/zowe.config.json
+++ b/__tests__/__integration__/cli/list/__resources__/zowe.config.json
@@ -4,20 +4,21 @@
             "type": "sample",
             "properties": {
                 "port": 443
-            }
+            },
+            "secure": []
         },
         "my_base": {
             "type": "base",
             "properties": {
                 "host": "old.host.com",
                 "user": "admin"
-            }
+            },
+            "secure": []
         }
     },
     "defaults": {
         "sample": "my_sample",
         "base": "my_base"
     },
-    "plugins": [],
-    "secure": []
+    "autoStore": true
 }

--- a/__tests__/__integration__/cli/list/__resources__/zowe.config.user.json
+++ b/__tests__/__integration__/cli/list/__resources__/zowe.config.user.json
@@ -5,12 +5,12 @@
             "properties": {
                 "user": "user1",
                 "password": "123456"
-            }
+            },
+            "secure": []
         }
     },
     "defaults": {
         "sample": "my_sample"
     },
-    "plugins": [],
-    "secure": []
+    "autoStore": true
 }

--- a/__tests__/__integration__/cli/list/__snapshots__/cli.list.test.integration.test.ts.snap
+++ b/__tests__/__integration__/cli/list/__snapshots__/cli.list.test.integration.test.ts.snap
@@ -26,19 +26,19 @@ exports[`zowe-cli-sample list command should display the help 1`] = `
  GLOBAL OPTIONS
  --------------
 
-   --response-format-json  | --rfj (boolean)
+   --response-format-json | --rfj (boolean)
 
       Produce JSON formatted data from a command
 
-   --help  | -h (boolean)
+   --help | -h (boolean)
 
       Display help text
 
-   --help-examples  (boolean)
+   --help-examples (boolean)
 
       Display examples for all the commands in a group
 
-   --help-web  | --hw (boolean)
+   --help-web | --hw (boolean)
 
       Display HTML help in browser
 

--- a/__tests__/cli/list/ListBaseHandler.test.ts
+++ b/__tests__/cli/list/ListBaseHandler.test.ts
@@ -9,6 +9,7 @@
  *
  */
 
+import { mockHandlerParameters } from "@zowe/cli-test-utils";
 import { IHandlerParameters, ISession } from "@zowe/imperative";
 import { ListBaseHandler } from "../../../src/cli/list/ListBaseHandler";
 
@@ -18,41 +19,7 @@ class ListTestHandler extends ListBaseHandler {
     }
 }
 
-const DEFAULT_PARAMETERS: Partial<IHandlerParameters> = {
-    response: {
-        data: {
-            setMessage: jest.fn((setMsgArgs) => {
-                expect("" + setMsgArgs).toMatchSnapshot();
-                return "";
-            }),
-            setObj: jest.fn((setObjArgs) => {
-                expect(setObjArgs).toMatchSnapshot();
-            }),
-            setExitCode: jest.fn()
-        },
-        console: {
-            log: jest.fn((logs) => {
-                expect("" + logs).toMatchSnapshot();
-                return "";
-            }),
-            error: jest.fn((errors) => {
-                expect("" + errors).toMatchSnapshot();
-                return "";
-            }),
-            errorHeader: jest.fn(() => undefined),
-            prompt: jest.fn(() => undefined)
-        },
-        progress: {
-            startBar: jest.fn((parms) => undefined),
-            endBar: jest.fn(() => undefined)
-        },
-        format: {
-            output: jest.fn((parms) => {
-                expect(parms).toMatchSnapshot();
-            })
-        }
-    }
-};
+const DEFAULT_PARAMETERS: IHandlerParameters = mockHandlerParameters({} as any);
 
 describe("ListBaseHandler", () => {
     let finalSessCfg: ISession;

--- a/__tests__/cli/list/directory-contents/DirectoryContents.handler.test.ts
+++ b/__tests__/cli/list/directory-contents/DirectoryContents.handler.test.ts
@@ -9,9 +9,10 @@
  *
  */
 
-import {CheckStatus} from "@zowe/zosmf-for-zowe-sdk";
-import {Files} from "../../../../src/api/Files";
-import {IHandlerParameters} from "@zowe/imperative";
+import { CheckStatus } from "@zowe/zosmf-for-zowe-sdk";
+import { Files } from "../../../../src/api/Files";
+import { mockHandlerParameters } from "@zowe/cli-test-utils";
+import { IHandlerParameters } from "@zowe/imperative";
 import { DirectoryContentsDefinition } from "../../../../src/cli/list/directory-contents/DirectoryContents.definition";
 import * as DirectoryContentsHandler from "../../../../src/cli/list/directory-contents/DirectoryContents.handler";
 
@@ -19,53 +20,10 @@ jest.mock("../../../../src/api/Files");
 
 process.env.FORCE_COLOR = "0";
 
-const DEFAULT_PARAMETERS: IHandlerParameters = {
-    arguments: {
-        $0: "bright",
-        _: ["zowe-cli-sample", "list", "directory-contents"],
-    },
+const DEFAULT_PARAMETERS: IHandlerParameters = mockHandlerParameters({
     positionals: ["zowe-cli-sample", "list", "directory-contents"],
-    profiles: {
-        get: (type: string) => {
-            return {};
-        }
-    } as any,
-    response: {
-        data: {
-            setMessage: jest.fn((setMsgArgs): string => {
-                expect("" + setMsgArgs).toMatchSnapshot();
-                return "";
-            }),
-            setObj: jest.fn((setObjArgs) => {
-                expect(setObjArgs).toMatchSnapshot();
-            }),
-            setExitCode: jest.fn()
-        },
-        console: {
-            log: jest.fn((logs) => {
-                expect("" + logs).toMatchSnapshot();
-                return "";
-            }),
-            error: jest.fn((errors) => {
-                expect("" + errors).toMatchSnapshot();
-                return "";
-            }),
-            errorHeader: jest.fn(() => undefined),
-            prompt: jest.fn(() => undefined)
-        },
-        progress: {
-            startBar: jest.fn((parms) => undefined),
-            endBar: jest.fn(() => undefined)
-        },
-        format: {
-            output: jest.fn((parms) => {
-                expect(parms).toMatchSnapshot();
-            })
-        }
-    },
-    definition: DirectoryContentsDefinition,
-    fullDefinition: DirectoryContentsDefinition,
-};
+    definition: DirectoryContentsDefinition
+});
 
 describe("directory-contents Handler", () => {
     afterEach(() => {

--- a/__tests__/cli/list/profile-args/ProfileArgs.handler.test.ts
+++ b/__tests__/cli/list/profile-args/ProfileArgs.handler.test.ts
@@ -9,57 +9,15 @@
  *
  */
 
+import { mockHandlerParameters } from "@zowe/cli-test-utils";
 import { IHandlerParameters, ImperativeConfig } from "@zowe/imperative";
 import { ProfileArgsDefinition } from "../../../../src/cli/list/profile-args/ProfileArgs.definition";
 import * as ProfileArgsHandler from "../../../../src/cli/list/profile-args/ProfileArgs.handler";
 
-const DEFAULT_PARAMETERS: IHandlerParameters = {
-    arguments: {
-        $0: "bright",
-        _: ["brightside-sample-plugin", "list", "profile-args"],
-    },
-    positionals: [],
-    profiles: {
-        get: (type: string) => {
-            return {};
-        }
-    } as any,
-    response: {
-        data: {
-            setMessage: jest.fn((setMsgArgs) => {
-                expect("" + setMsgArgs).toMatchSnapshot();
-                return "";
-            }),
-            setObj: jest.fn((setObjArgs) => {
-                expect(setObjArgs).toMatchSnapshot();
-            }),
-            setExitCode: jest.fn()
-        },
-        console: {
-            log: jest.fn((logs) => {
-                expect("" + logs).toMatchSnapshot();
-                return "";
-            }),
-            error: jest.fn((errors) => {
-                expect("" + errors).toMatchSnapshot();
-                return "";
-            }),
-            errorHeader: jest.fn(() => undefined),
-            prompt: jest.fn(() => undefined)
-        },
-        progress: {
-            startBar: jest.fn((parms) => undefined),
-            endBar: jest.fn(() => undefined)
-        },
-        format: {
-            output: jest.fn((parms) => {
-                expect(parms).toMatchSnapshot();
-            })
-        }
-    },
-    definition: ProfileArgsDefinition,
-    fullDefinition: ProfileArgsDefinition
-};
+const DEFAULT_PARAMETERS: IHandlerParameters = mockHandlerParameters({
+    positionals: ["brightside-sample-plugin", "list", "profile-args"],
+    definition: ProfileArgsDefinition
+});
 
 describe("profile-args Handler", () => {
     afterAll(() => {


### PR DESCRIPTION
This fixes compilation errors in CLI handler unit tests that were missing the required property `IHandlerParameters.stdin` in mocks.