### PR TITLE
Fix missing link to profiles tutorial

### DIFF
--- a/docs/tutorials/files-util/FilesUtilPlugin.md
+++ b/docs/tutorials/files-util/FilesUtilPlugin.md
@@ -209,4 +209,4 @@ Install the `diff2html` CLI via `npm install -g diff2html-cli`. Then, pipe your 
 - `zowe files-util diff data-sets "kelda16.work.jcl(iefbr14)" "kelda16.work.jcl(iefbr15)" | diff2html -i stdin`
 
 ## Next steps
-Try the [Implementing profiles in a plug-in](url) tutorial to learn about using profiles with your plug-in.
+Try the [Implementing profiles in a plug-in](/docs/tutorials/profile-example/ProfilePlugin.md) tutorial to learn about using profiles with your plug-in.


### PR DESCRIPTION
**What It Does**
Adds a missing link to the profile example in the "Developing a new plug-in" page.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->